### PR TITLE
[Fix] Change the doRun and loadProjectConfig order 

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -100,11 +100,11 @@ class Application extends \Symfony\Component\Console\Application
         $this->container->set('logger', new ConsoleLogger($output));
 
         $this->config = $this->container->get('config');
-
-        $this->loadProjectConfig($input);
         $this->initCommands();
+        $applicationRun = parent::doRun($input, $output);
+        $this->loadProjectConfig($input);
 
-        return parent::doRun($input, $output);
+        return $applicationRun;
     }
     /**
      * Initialise the available commands.
@@ -196,6 +196,8 @@ class Application extends \Symfony\Component\Console\Application
     /**
      * @param InputInterface $input
      * @throws Exception\ConfigurationException
+     * @throws \DI\DependencyException
+     * @throws \DI\NotFoundException
      */
     private function loadProjectConfig(InputInterface $input)
     {
@@ -211,7 +213,7 @@ class Application extends \Symfony\Component\Console\Application
             $this->config->merge((new FileLoader($file))->asConfig());
         } elseif ($canError) {
             throw new \InvalidArgumentException(
-                sprintf('The project config file at %s could not be read', $file)
+                sprintf('The project config file at %s could not be read or doesn\'t exist', $file)
             );
         }
     }


### PR DESCRIPTION
https://github.com/Space48/magedbm2/issues/36

It seems that the issue is caused by the class ArgvInput not having the tokens parsed to options and arguments, causing `$input->hasOption(Option::PROJECT_CONFIG_FILE) `never to result in True. By simply first running the parent method of `Application::doRun`

I think it can be very simply fixed by changing the order of `Application::doRun` and `Application::loadProjectConfig`.