### PR TITLE
Overhaul configuration loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- The `configure` command now presents the user will files to edit and a preview of the changes before writing to file.
+
+### Fixed
+
+- The `--project-config` option is now respected and the configuration file is loaded at the correct time.
+
+## [2.0.2] - 2018-09-08
+
+### Fixed
+
+
+- The put command no longer performs Magento 2 discovery if the required database options are specified as command-line parameters.
+- The admin table strip group no longer removes administrator roles, only users.
+
+
+## [2.0.1] - 2018-04-17
+
+### Changed
+
+- Strip `DEFINER` from `CREATE TRIGGER` statements.
+- Don't allow blank `--db-*` options.
+
+## [2.0.0] - 2018-04-12
+
+### Added
+
+- Support to `export` and `import` anonymised data.
+- Project level configuration so that you can include a `.magedbm2.yml` in your repository.
+
+### Changed
+
+- No longer requires magerun
+
+
+## [1.0.0] - 2017-06-08
+
+### Added
+
+- Initial release.

--- a/etc/di.php
+++ b/etc/di.php
@@ -54,22 +54,12 @@ return [
         return $resolver->getDistFilePath();
     },
 
-    'config_file.global' => function (\Meanbee\Magedbm2\Application\ConfigFileResolver $resolver) {
-        return $resolver->getUserFilePath();
-    },
-
-    'config_file.project' => function (\Meanbee\Magedbm2\Application\ConfigFileResolver $resolver) {
-        return $resolver->getProjectFilePath();
-    },
-
     'config' => function (\DI\Container $c) {
         /** @var \Psr\Log\LoggerInterface $logger */
         $logger = $c->get('logger');
 
         $files = [
-            $c->get('config_file.dist'),
-            $c->get('config_file.global'),
-            $c->get('config_file.project'),
+            $c->get('config_file.dist')
         ];
 
         $config = new \Meanbee\Magedbm2\Application\Config();

--- a/src/Application.php
+++ b/src/Application.php
@@ -64,8 +64,6 @@ class Application extends \Symfony\Component\Console\Application
 
         $this->container = $builder->build();
         $this->container->set(Application::class, $this);
-
-        $this->configureGlobalOptions();
     }
 
     /**
@@ -101,11 +99,10 @@ class Application extends \Symfony\Component\Console\Application
 
         $this->config = $this->container->get('config');
         $this->initCommands();
-        $applicationRun = parent::doRun($input, $output);
-        $this->loadProjectConfig($input);
 
-        return $applicationRun;
+        return parent::doRun($input, $output);
     }
+
     /**
      * Initialise the available commands.
      *
@@ -118,103 +115,6 @@ class Application extends \Symfony\Component\Console\Application
 
         foreach ($commands as $command) {
             $this->add($command);
-        }
-    }
-
-    private function configureGlobalOptions()
-    {
-        $definition = $this->getDefinition();
-
-        $definition
-            ->addOption(new InputOption(
-                Option::GLOBAL_CONFIG_FILE,
-                null,
-                InputOption::VALUE_REQUIRED,
-                "Global configuration file to use",
-                $this->container->get('config_file.global')
-            ));
-
-        $definition
-            ->addOption(new InputOption(
-                Option::PROJECT_CONFIG_FILE,
-                null,
-                InputOption::VALUE_OPTIONAL,
-                "Project configuration file to use (will search for .magedbm2.yml in your current working directory " .
-                "if not specified)"
-            ));
-
-        $definition
-            ->addOption(new InputOption(
-                Option::DB_HOST,
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Database host'
-            ));
-
-        $definition
-            ->addOption(new InputOption(
-                Option::DB_PORT,
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Database port',
-                3306
-            ));
-
-        $definition
-            ->addOption(new InputOption(
-                Option::DB_USER,
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Database username'
-            ));
-
-        $definition
-            ->addOption(new InputOption(
-                Option::DB_PASS,
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Database password'
-            ));
-
-        $definition
-            ->addOption(new InputOption(
-                Option::DB_NAME,
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Database name'
-            ));
-
-
-        $definition->addOption(new InputOption(
-            Option::ROOT_DIR,
-            null,
-            InputOption::VALUE_REQUIRED,
-            "Magento 2 root directory"
-        ));
-    }
-
-    /**
-     * @param InputInterface $input
-     * @throws Exception\ConfigurationException
-     * @throws \DI\DependencyException
-     * @throws \DI\NotFoundException
-     */
-    private function loadProjectConfig(InputInterface $input)
-    {
-        $canError = false;
-        $file = $this->container->get('config_file.project');
-
-        if ($input->hasOption(Option::PROJECT_CONFIG_FILE)) {
-            $canError = true;
-            $file = $input->getOption(Option::PROJECT_CONFIG_FILE);
-        }
-
-        if (file_exists($file) && is_readable($file)) {
-            $this->config->merge((new FileLoader($file))->asConfig());
-        } elseif ($canError) {
-            throw new \InvalidArgumentException(
-                sprintf('The project config file at %s could not be read or doesn\'t exist', $file)
-            );
         }
     }
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -100,11 +100,11 @@ class Application extends \Symfony\Component\Console\Application
         $this->container->set('logger', new ConsoleLogger($output));
 
         $this->config = $this->container->get('config');
-
-        $this->loadProjectConfig($input);
         $this->initCommands();
+        $applicationRun = parent::doRun($input, $output);
+        $this->loadProjectConfig($input);
 
-        return parent::doRun($input, $output);
+        return $applicationRun;
     }
     /**
      * Initialise the available commands.
@@ -196,6 +196,8 @@ class Application extends \Symfony\Component\Console\Application
     /**
      * @param InputInterface $input
      * @throws Exception\ConfigurationException
+     * @throws \DI\DependencyException
+     * @throws \DI\NotFoundException
      */
     private function loadProjectConfig(InputInterface $input)
     {
@@ -211,7 +213,7 @@ class Application extends \Symfony\Component\Console\Application
             $this->config->merge((new FileLoader($file))->asConfig());
         } elseif ($canError) {
             throw new \InvalidArgumentException(
-                sprintf('The project config file at %s could not be read', $file)
+                sprintf('The project config file at %s could not be read or doesn\'t exist', $file)
             );
         }
     }

--- a/src/Application/Config.php
+++ b/src/Application/Config.php
@@ -85,11 +85,11 @@ class Config implements ConfigInterface, LoggerAwareInterface
                     $this->logger->info('Found Magento installation at ' . $rootDiscovery->getRootDirectory());
 
                     $this->databaseCredentials = new DatabaseCredentials(
-                        $configReader->getDatabaseName(),
-                        $configReader->getDatabaseUsername(),
-                        $configReader->getDatabasePassword(),
-                        $configReader->getDatabaseHost(),
-                        $configReader->getDatabasePort()
+                        $configReader->getDatabaseName() ?? '',
+                        $configReader->getDatabaseUsername() ?? '',
+                        $configReader->getDatabasePassword() ?? '',
+                        $configReader->getDatabaseHost() ?? '',
+                        $configReader->getDatabasePort() ?? ''
                     );
 
                     return $this->databaseCredentials;

--- a/src/Application/Config/Option.php
+++ b/src/Application/Config/Option.php
@@ -26,26 +26,18 @@ final class Option
     const CLEAN_COUNT = 'clean';
     const NO_CLEAN = 'no-clean';
 
-    /**
-     * Get the options that are allowed to be defined in the global configuration file.
-     *
-     * @return array
-     */
-    public static function getAllowedGlobalConfig(): array
-    {
-        return [
-            self::TABLE_GROUPS,
-            self::TEMPORARY_DIR,
-            self::CLEAN_COUNT,
-        ];
-    }
+    const STORAGE_SECRET_KEY = 'secret-key';
+    const STORAGE_DATA_BUCKET = 'data-bucket';
+    const STORAGE_BUCKET = 'bucket';
+    const STORAGE_REGION = 'region';
+    const STORAGE_ACCESS_KEY = 'access-key';
 
     /**
-     * Get the options that are allowed to be defined in the project configuration file.
+     * Options that a user is allowed to save in a configuration file.
      *
      * @return array
      */
-    public static function getAllowedProjectConfig(): array
+    public static function allowUserToPersist()
     {
         return [
             self::DB_HOST,
@@ -54,11 +46,10 @@ final class Option
             self::DB_PASS,
             self::DB_PORT,
 
-            self::TABLE_GROUPS,
-
-            self::TEMPORARY_DIR,
-            self::STRIP,
-            self::CLEAN_COUNT
+            self::STORAGE_ACCESS_KEY,
+            self::STORAGE_SECRET_KEY,
+            self::STORAGE_BUCKET,
+            self::STORAGE_REGION
         ];
     }
 

--- a/src/Command/ExportCommand.php
+++ b/src/Command/ExportCommand.php
@@ -97,6 +97,8 @@ class ExportCommand extends BaseCommand
 
     protected function configure()
     {
+        parent::configure();
+
         $this
             ->setName(self::NAME)
             ->setDescription('Create an anonymised data export of sensitive tables');

--- a/src/Command/GetCommand.php
+++ b/src/Command/GetCommand.php
@@ -62,6 +62,8 @@ class GetCommand extends BaseCommand
      */
     protected function configure()
     {
+        parent::configure();
+
         $this
             ->setName(self::NAME)
             ->setDescription("Download and import a database backup.")

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -83,6 +83,8 @@ class ImportCommand extends BaseCommand
 
     protected function configure()
     {
+        parent::configure();
+
         $this
             ->setName(self::NAME)
             ->setDescription('Import a magedbm2-generated anonymised data export.');

--- a/src/Command/LsCommand.php
+++ b/src/Command/LsCommand.php
@@ -3,6 +3,7 @@
 namespace Meanbee\Magedbm2\Command;
 
 use Meanbee\Magedbm2\Application\ConfigInterface;
+use Meanbee\Magedbm2\Exception\ConfigurationException;
 use Meanbee\Magedbm2\Exception\ServiceException;
 use Meanbee\Magedbm2\Service\Storage\Data\File;
 use Meanbee\Magedbm2\Service\StorageFactory;
@@ -73,10 +74,14 @@ class LsCommand extends BaseCommand
             $this->output->writeln('');
         }
 
-        if ($this->dataStorage->validateConfiguration()) {
-            $this->output->writeln("Storage: Data Exports");
-            $this->output->writeln("========================================");
-            $this->renderStorage($this->dataStorage, $input, $output);
+        try {
+            if ($this->dataStorage->validateConfiguration()) {
+                $this->output->writeln("Storage: Data Exports");
+                $this->output->writeln("========================================");
+                $this->renderStorage($this->dataStorage, $input, $output);
+            }
+        } catch (ConfigurationException $configurationException) {
+            $this->output->writeln('Not rendering data exports due to: ' . $configurationException->getMessage());
         }
 
         return static::RETURN_CODE_SUCCESS;

--- a/src/Service/Storage/S3.php
+++ b/src/Service/Storage/S3.php
@@ -300,11 +300,11 @@ class S3 implements StorageInterface, LoggerAwareInterface
      */
     public function validateConfiguration(): bool
     {
-        if ($this->purpose === StorageInterface::PURPOSE_STRIPPED_DATABASE && !$this->getConfig()->get(Option::STORAGE_BUCKET)) {
+        if ($this->purpose === StorageInterface::PURPOSE_STRIPPED_DATABASE && !$this->getConfig()->get(Option::STORAGE_BUCKET, true)) {
             throw new ConfigurationException('A bucket needs to be defined');
         }
 
-        if ($this->purpose === StorageInterface::PURPOSE_ANONYMISED_DATA && !$this->getConfig()->get(Option::STORAGE_DATA_BUCKET)) {
+        if ($this->purpose === StorageInterface::PURPOSE_ANONYMISED_DATA && !$this->getConfig()->get(Option::STORAGE_DATA_BUCKET, true)) {
             throw new ConfigurationException('A data bucket needs to be defined');
         }
 

--- a/tests/Command/ConfigureCommandTest.php
+++ b/tests/Command/ConfigureCommandTest.php
@@ -48,11 +48,25 @@ class ConfigureCommandTest extends AbstractCommandTest
             ->method("write")
             ->with(
                 $this->equalTo($this->configPath),
-                $this->equalTo("test-option: test-option-value\nother-option: other-option-value\n")
+                $this->equalTo("db-host: 127.0.0.1\ndb-port: '3333'\n")
             );
 
         $tester = $this->getCommandTester($filesystem);
-        $tester->execute([], ["interactive" => true]);
+        $tester->setInputs([
+            0, // File selection,
+            '127.0.0.1',
+            '',
+            '',
+            '',
+            '3333',
+            '',
+            '',
+            '',
+            '',
+            'yes' // Confirm write
+        ]);
+
+        $tester->execute([''], ["interactive" => true]);
     }
 
     /**
@@ -68,11 +82,15 @@ class ConfigureCommandTest extends AbstractCommandTest
             ->method("write")
             ->with(
                 $this->equalTo($this->configPath),
-                $this->equalTo("test-option: default-test-option-value\nother-option: null\n")
+                $this->equalTo("db-host: 127.0.0.1\ndb-port: '3333'\n")
             );
 
         $tester = $this->getCommandTester($filesystem);
-        $tester->execute([], ["interactive" => false]);
+        $tester->execute([
+            'config-file' => $this->configPath,
+            '--db-host' => '127.0.0.1',
+            '--db-port' => '3333'
+        ], ["interactive" => false]);
     }
 
     /**

--- a/tests/Service/Storage/S3Test.php
+++ b/tests/Service/Storage/S3Test.php
@@ -11,33 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 class S3Test extends TestCase
 {
-
-    /**
-     * Test that the service sets the required options on the application.
-     *
-     * @test
-     */
-    public function testConsoleOptions()
-    {
-        $app = new Application();
-
-        $service = new S3($app, $this->getConfigMock());
-
-        $options = [
-            "access-key",
-            "secret-key",
-            "region",
-            "bucket",
-        ];
-
-        foreach ($options as $option) {
-            $this->assertTrue(
-                $app->getDefinition()->hasOption($option),
-                sprintf("Expected application option '%s' not found.", $option)
-            );
-        }
-    }
-
     /**
      * Test that project names are extracted from available objects.
      *
@@ -68,7 +41,7 @@ class S3Test extends TestCase
                 ["Key" => "test-project-bar/backup-file-1.sql.gz"],
             ]);
 
-        $service = new S3($app, $config, $client);
+        $service = new S3($config, $client);
 
         $this->assertEquals(
             [
@@ -119,7 +92,7 @@ class S3Test extends TestCase
                 ],
             ]);
 
-        $service = new S3($app, $config, $client);
+        $service = new S3($config, $client);
 
         $file1 = new File();
         $file1->name = "backup-file-1.sql.gz";
@@ -184,7 +157,7 @@ class S3Test extends TestCase
                 ],
             ]);
 
-        $service = new S3($app, $config, $client);
+        $service = new S3($config, $client);
 
         $this->assertEquals(
             "backup-file-2.sql.gz",
@@ -231,7 +204,7 @@ class S3Test extends TestCase
                 "ObjectURL" => $expected_result
             ]);
 
-        $service = new S3($app, $config, $client);
+        $service = new S3($config, $client);
 
         $this->assertEquals(
             $expected_result,
@@ -276,7 +249,7 @@ class S3Test extends TestCase
                 "SaveAs" => $result,
             ]));
 
-        $service = new S3($app, $config, $client);
+        $service = new S3($config, $client);
 
         $this->assertEquals(
             $result,
@@ -316,7 +289,7 @@ class S3Test extends TestCase
                 "Key"    => sprintf("%s/%s", $project, $filename),
             ]));
 
-        $service = new S3($app, $config, $client);
+        $service = new S3($config, $client);
 
         $service->delete($project, $filename);
     }
@@ -394,7 +367,7 @@ class S3Test extends TestCase
             ->method("deleteObjects")
             ->with($this->equalTo($expected_query));
 
-        $service = new S3($app, $config, $client);
+        $service = new S3($config, $client);
 
         $service->clean($project, $keep);
     }


### PR DESCRIPTION
The loading of the configuration was messy with the ability to override file based configuration with parameters when called with command options. This has caused race conditions due to the configuration files themselves) being able to be overridden with an option too.

Unfortunately @Quintenps's approach switch the ordering of the arguments was a band aid for the bigger architectural problem.

- Move the parsing and loading of configuration from the base Application class to just before the command is executed, giving time for all inputs to be read and configuration overwritten, if required.

- Reduce the responsibility of the S3 client to specify options, and bundle those options into the global options list.

- Redo the configure command to allow for the specification of a file to write to.

Fixes #36.