### PR TITLE
Set the default temp directory on initial creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **BREAKING**: Renamed `tmp_dir` configuration option to `tmp-dir`.
 - The `configure` command now presents the user will files to edit and a preview of the changes before writing to file.
 
 ### Fixed

--- a/etc/di.php
+++ b/etc/di.php
@@ -83,6 +83,12 @@ return [
             );
         }
 
+        if (!$config->get(\Meanbee\Magedbm2\Application\Config\Option::TEMPORARY_DIR, true)) {
+            $config->merge(new \Meanbee\Magedbm2\Application\Config([
+                \Meanbee\Magedbm2\Application\Config\Option::TEMPORARY_DIR => sys_get_temp_dir()
+            ]));
+        }
+
         return $config;
     },
 ];

--- a/src/Application/Config.php
+++ b/src/Application/Config.php
@@ -37,8 +37,6 @@ class Config implements ConfigInterface, LoggerAwareInterface
     {
         $this->values = new Dot($values);
         $this->logger = new NullLogger();
-
-        $this->initialiseCalculatedValues();
     }
 
     /**
@@ -143,22 +141,6 @@ class Config implements ConfigInterface, LoggerAwareInterface
         }
 
         return $tableGroups;
-    }
-
-    private function initialiseCalculatedValues()
-    {
-        if (!$this->values->has(Option::TEMPORARY_DIR)) {
-            $this->values->set(Option::TEMPORARY_DIR, $this->generateTmpDir());
-        }
-    }
-
-    /**
-     * @return mixed
-     * @throws \RuntimeException
-     */
-    private function generateTmpDir()
-    {
-        return sys_get_temp_dir();
     }
 
     /**

--- a/src/Application/Config/Option.php
+++ b/src/Application/Config/Option.php
@@ -16,8 +16,8 @@ final class Option
     const DB_PORT = 'db-port';
 
     const TABLE_GROUPS = 'table-groups';
-
-    const TEMPORARY_DIR = 'tmp_dir';
+    
+    const TEMPORARY_DIR = 'tmp-dir';
 
     const FORCE = 'force';
     const DOWNLOAD_ONLY = 'download-only';

--- a/tests/Application/ConfigTest.php
+++ b/tests/Application/ConfigTest.php
@@ -97,4 +97,14 @@ class ConfigTest extends TestCase
         $this->assertCount(10, $config_1->get('deep_nesting.level_1.level_2.level_3'));
         $this->assertCount(5, $config_1->get('deep_nesting.level_1.level_2a'));
     }
+
+    public function testOverrideInitialisedValue()
+    {
+        $initialConfig = new Config();
+        $initialConfig->merge(new Config([
+            'tmp-dir' => '/not/tmp'
+        ]));
+
+        $this->assertEquals('/not/tmp', $initialConfig->get('tmp-dir'));
+    }
 }

--- a/tests/Service/Storage/S3Test.php
+++ b/tests/Service/Storage/S3Test.php
@@ -229,7 +229,7 @@ class S3Test extends TestCase
 
         $config = new Application\Config([
             'bucket' => $bucket,
-            'tmp_dir' => $tmp_dir
+            'tmp-dir' => $tmp_dir
         ]);
 
         $client = $this->getMockBuilder(S3Client::class)


### PR DESCRIPTION
- This gets around newly created Config objects always having an initialised tmp-dir value
- Breaking: Change configuration option to tmp-dir for consistency with everything else

Fixes #32.