### PR TITLE
Read and write UTF-8 encoded backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - **BREAKING**: Renamed `tmp_dir` configuration option to `tmp-dir`.
+- **BREAKING**: All MySQL interactions now use `utf-8` as the default charset, potentially making backups created with an older versions unimportable. Use `--download-only` and import manually if you run into this or update on your server and `put` a new database backup.
 - The `configure` command now presents the user will files to edit and a preview of the changes before writing to file.
 
 ### Fixed

--- a/src/Application/Config/DatabaseCredentials.php
+++ b/src/Application/Config/DatabaseCredentials.php
@@ -90,7 +90,7 @@ class DatabaseCredentials
     {
         return new \PDO(
             sprintf(
-                'mysql:dbname=%s;host=%s;port=%s',
+                'mysql:dbname=%s;host=%s;port=%s;charset=utf8',
                 $this->getName(),
                 $this->getHost(),
                 $this->getPort()

--- a/src/Service/Database/Shell.php
+++ b/src/Service/Database/Shell.php
@@ -69,7 +69,7 @@ class Shell implements DatabaseInterface
      */
     public function import($file)
     {
-        $process = (new Pipe())
+        $command = (new Pipe())
             ->command(
                 (new Gunzip())
                     ->argument('-c')
@@ -77,8 +77,12 @@ class Shell implements DatabaseInterface
             )->command(
                 (new Mysql())
                     ->arguments($this->getCredentialOptions())
+                    ->argument('--default-character-set=utf8')
                     ->argument($this->config->getDatabaseCredentials()->getName())
-            )->toProcess();
+            );
+        $process = $command->toProcess();
+
+        $this->logger->debug($command->toString());
 
         $process->start();
 
@@ -119,6 +123,7 @@ class Shell implements DatabaseInterface
             $commands[] = $this->createDumpProcess()
                 ->argument('--no-data')
                 ->argument('--add-drop-table')
+                ->argument('--default-character-set=utf8')
                 ->argument($databaseName)
                 ->argument($strip_tables)
                 ->output($structureOutputFile);
@@ -134,6 +139,7 @@ class Shell implements DatabaseInterface
         $commands[] = $this->createDumpProcess()
             ->arguments($dataDumpOptions)
             ->argument('--add-drop-table')
+            ->argument('--default-character-set=utf8')
             ->argument($databaseName)
             ->output($dataOutputFile);
 


### PR DESCRIPTION
Required to support larger than latin characters that may be stored in exported tables.

Fixes #24.