### PR TITLE
Replace map with mapping function

### DIFF
--- a/src/Application/Config/Option.php
+++ b/src/Application/Config/Option.php
@@ -72,21 +72,8 @@ final class Option
         // Don't allow instantiation.
     }
 
-    public static function getYamlOptionMap()
+    public static function mapYamlOptionToConfigOption(string $yamlOption)
     {
-        return [
-            'root_dir' => self::ROOT_DIR,
-            self::YAML_DB_HOST => self::DB_HOST,
-            self::YAML_DB_NAME => self::DB_NAME,
-            self::YAML_DB_USER => self::DB_USER,
-            self::YAML_DB_PASS => self::DB_PASS,
-            self::YAML_DB_PORT => self::DB_PORT,
-            'table_groups' => self::TABLE_GROUPS,
-            'tmp_dir' => self::TEMPORARY_DIR,
-            self::YAML_STORAGE_SECRET_KEY => self::STORAGE_SECRET_KEY,
-            self::YAML_ANONYMISED_BUCKET => self::STORAGE_ANONYMISED_BUCKET,
-            self::YAML_STORAGE_ACCESS_KEY => self::STORAGE_ACCESS_KEY,
-            self::YAML_ANONYMISED_REGION => self::STORAGE_ANONYMISED_REGION
-        ];
+        return str_replace('_', '-', $yamlOption);
     }
 }

--- a/src/Application/ConfigLoader/FileLoader.php
+++ b/src/Application/ConfigLoader/FileLoader.php
@@ -63,10 +63,10 @@ class FileLoader implements ConfigLoaderInterface
 
     private function formatConfigVariableNames(array $variables)
     {
-        $yamlToConfigVariableNameMap = Option::getYamlOptionMap();
         foreach ($variables as $variableName => $variableValue) {
-            if (array_key_exists($variableName, $yamlToConfigVariableNameMap)) {
-                $variables[$yamlToConfigVariableNameMap[$variableName]] = $variableValue;
+            $configOption = Option::mapYamlOptionToConfigOption($variableName);
+            if ($configOption && $configOption !== $variableName) {
+                $variables[$configOption] = $variableValue;
                 unset($variables[$variableName]);
             }
         }

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -205,10 +205,8 @@ HELP
      */
     protected function populateOptions(InputInterface $input, SymfonyStyle $style, array $data): array
     {
-        $yamlOptionMap = Option::getYamlOptionMap();
-
         foreach (Option::allowUserToPersist() as $optionName) {
-            $configName = $yamlOptionMap[$optionName] ?? $optionName;
+            $configName = Option::mapYamlOptionToConfigOption($optionName)?? $optionName;
             if ($input->isInteractive()) {
                 $currentValue = $this->config->get($configName, true);
                 if ($currentValue) {


### PR DESCRIPTION
- if we're just turning underscores into hyphens when mapping from yaml variables to config variables, there's no need for the functionality to be any more complex than a replace function call