### PR TITLE
Initial support for DB SSL CA

### DIFF
--- a/src/Application/Config.php
+++ b/src/Application/Config.php
@@ -87,7 +87,8 @@ class Config implements ConfigInterface, LoggerAwareInterface
                         $configReader->getDatabaseUsername() ?? '',
                         $configReader->getDatabasePassword() ?? '',
                         $configReader->getDatabaseHost() ?? '',
-                        $configReader->getDatabasePort() ?? ''
+                        $configReader->getDatabasePort() ?? '',
+                        // @TODO: Support SSL CA from config reader.
                     );
 
                     return $this->databaseCredentials;
@@ -103,7 +104,8 @@ class Config implements ConfigInterface, LoggerAwareInterface
                 $this->get(Option::DB_USER, true) ?? '',
                 $this->get(Option::DB_PASS, true) ?? '',
                 $this->get(Option::DB_HOST, true) ?? 'localhost',
-                $this->get(Option::DB_PORT, true) ?? '3306'
+                $this->get(Option::DB_PORT, true) ?? '3306',
+                $this->get(Option::DB_SSL_CA, true) ?? null,
             );
         }
 

--- a/src/Application/Config/DatabaseCredentials.php
+++ b/src/Application/Config/DatabaseCredentials.php
@@ -29,18 +29,25 @@ class DatabaseCredentials
      */
     private $port;
 
+    /**
+     * @var string
+     */
+    private $sslCAPath;
+
     public function __construct(
         string $name,
         string $username,
         string $password = null,
         string $host = 'localhost',
-        string $port = '3306'
+        string $port = '3306',
+        string $sslCAPath = null
     ) {
         $this->name = $name;
         $this->username = $username;
         $this->password = $password;
         $this->host = $host;
         $this->port = $port;
+        $this->sslCAPath = $sslCAPath;
     }
 
     /**
@@ -83,11 +90,20 @@ class DatabaseCredentials
         return $this->port;
     }
 
+    public function getSSLCAPath(): ?string {
+        return $this->sslCAPath;
+    }
+
     /**
      * @return \PDO
      */
     public function createPDO(): \PDO
     {
+        $options = array()
+        if ($this->getSSLCAPath() !== null) {
+            $options[PDO::MYSQL_ATTR_SSL_CA] = $this->getSSLCAPath();
+            $options[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = false;
+        }
         return new \PDO(
             sprintf(
                 'mysql:dbname=%s;host=%s;port=%s;charset=utf8',
@@ -96,7 +112,8 @@ class DatabaseCredentials
                 $this->getPort()
             ),
             $this->getUsername(),
-            $this->getPassword()
+            $this->getPassword(),
+            $options
         );
     }
 }

--- a/src/Application/Config/Option.php
+++ b/src/Application/Config/Option.php
@@ -14,12 +14,14 @@ final class Option
     const DB_USER = 'db-user';
     const DB_PASS = 'db-pass';
     const DB_PORT = 'db-port';
+    const DB_SSL_CA = 'db-ssl-ca';
 
     const YAML_DB_HOST = 'db_host';
     const YAML_DB_NAME = 'db_name';
     const YAML_DB_USER = 'db_user';
     const YAML_DB_PASS = 'db_pass';
     const YAML_DB_PORT = 'db_port';
+    const YAML_DB_SSL_CA = 'db_ssl_ca';
 
     const TABLE_GROUPS = 'table-groups';
     
@@ -57,6 +59,7 @@ final class Option
             self::YAML_DB_USER,
             self::YAML_DB_PASS,
             self::YAML_DB_PORT,
+            self::YAML_DB_SSL_CA,
 
             self::YAML_STORAGE_ACCESS_KEY,
             self::YAML_STORAGE_SECRET_KEY,

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -165,6 +165,12 @@ abstract class BaseCommand extends Command implements LoggerAwareInterface
                     'Database name'
                 ),
                 new InputOption(
+                    Option::DB_SSL_CA,
+                    null,
+                    InputOption::VALUE_OPTIONAL,
+                    'Path to SSL CA e.g. /etc/ssl/my-cert.pem'
+                ),
+                new InputOption(
                     Option::ROOT_DIR,
                     null,
                     InputOption::VALUE_REQUIRED,

--- a/tests/Command/ConfigureCommandTest.php
+++ b/tests/Command/ConfigureCommandTest.php
@@ -65,6 +65,7 @@ class ConfigureCommandTest extends AbstractCommandTest
             '',
             '',
             '',
+            '',
             'yes' // Confirm write
         ]);
 


### PR DESCRIPTION
Currently magedbm2 does not support SSL connections to the database. This PR adds initial support.

I have not included support for the magento configuration reader (due to it being an external dependency and the repository has been archived - https://github.com/meanbee/libmageconf ), so it will currently only be supported when passed as a CLI argument or as part of the magedb2 yaml configuration file.

The change will be non-breaking by defaulting to not using an SSL connection and the parameter not being required.