### PR TITLE
Restire possibility to configure 'table groups' + added container for building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 build: magedbm2.phar
 
+build-in-container:
+	docker-compose run --rm build /bin/bash -c "cd /var/www/html && make build"
+
 clean:
 	rm -rf vendor box.phar composer.phar magedbm2.phar
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  build:
+    image: docker.io/php:8.0.30-cli
+
+    container_name: magedbm_build
+    volumes:
+      - ./:/var/www/html

--- a/src/Application/ConfigLoader/FileLoader.php
+++ b/src/Application/ConfigLoader/FileLoader.php
@@ -34,10 +34,6 @@ class FileLoader implements ConfigLoaderInterface
         try {
             $values = Yaml::parseFile($this->filePath);
 
-            if (is_array($values) && !$this->validateYamlVariables($values)) {
-                $this->configurationError();
-            }
-
             if (is_array($values)) {
                 $values = $this->formatConfigVariableNames($values);
             }
@@ -46,19 +42,6 @@ class FileLoader implements ConfigLoaderInterface
         } catch (ParseException $exception) {
             $this->configurationError();
         }
-    }
-
-    // yaml doesn't like variable names with hyphens (https://github.com/Space48/magedbm2/issues/21)
-    private function validateYamlVariables(array $variables)
-    {
-        $isValidYaml = true;
-        foreach ($variables as $variableName => $variableValue) {
-            if (strpos($variableName, '-') !== false) {
-                $isValidYaml = false;
-                break;
-            }
-        }
-        return $isValidYaml;
     }
 
     private function formatConfigVariableNames(array $variables)


### PR DESCRIPTION
- Added container for easy building on non-linux devices
- Removed the fix for hyphens variable names: it seams this had been  fixed somehow and hyphens now works, while deprecation of hyphens in fact makes it impossible to configure 'table-groups' property for adding project specific tables for stripping.