### PR TITLE
Removed column-statistics=0

### DIFF
--- a/src/Shell/Command/Mysqldump.php
+++ b/src/Shell/Command/Mysqldump.php
@@ -11,7 +11,6 @@ class Mysqldump extends Base
         $this->arguments([
             '--single-transaction',
             '--quick',
-            '--column-statistics=0',
             '--no-tablespaces'
         ]);
     }


### PR DESCRIPTION
column-statistics=0 is an argument not compatible with mysqldump from mariadb, this argument make mysqldump command to fail.

```
[alert] There was an error in one of the commands -- stopping others.
Failed to create a database backup file: There was an error exporting the database: mysqldump: unknown option '--skip-column-statistics'
```